### PR TITLE
2025 01 28 simpler state observation and dependency updates

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,11 +7,11 @@ rootProject.name = "MoRedux"
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("kotlin", "2.0.20")
+            version("kotlin", "2.1.10")
             version("axion", "1.18.9")
             version("vanniktech-publish", "0.29.0")
-            version("kotlinx-coroutines", "1.9.0")
-            version("junit-jupiter", "5.11.0")
+            version("kotlinx-coroutines", "1.10.1")
+            version("junit-jupiter", "5.11.4")
             version("google-truth", "1.4.4")
             version("mockito", "5.2.0")
 

--- a/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
+++ b/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * Register a [stateObserver] that will be notified everytime the state changes. A StateObserver may only
  * be registered once.
  *
- * @param processCurrentStateImmediately if true, the current state will be pushed into the passed [stateObserver]
+ * @param processCurrentStateImmediately if true, the current state will be pushed immediately into the passed [stateObserver]
  * @param stateObserver the StateObserver instance that listens upon onStateChanged
  * @return the [stateObserver]
  */
@@ -39,7 +39,7 @@ fun <STATE : State> Store<STATE>.addStateObserver(
 /**
  * Register a [callback] as a StateObserver. The [callback] will be treated like any other StateObserver
  *
- * @param processCurrentStateImmediately if true, the current state will be pushed into the passed [callback]
+ * @param processCurrentStateImmediately if true, the current state will be pushed immediately into the passed [callback]
  * @param callback the callback function with which a StateObserver is constructed
  * @return the StateObserver instance that was constructed out of [callback]
  * @see ObservationManager.addStateObserver
@@ -70,11 +70,11 @@ fun <STATE : State, VALUE> Store<STATE>.addSelector(
  * Register a [map] function as a Selector. The [map] will be wrapped in a Selector and is treated like any
  * other StateObserver.
  *
- * @param processCurrentStateImmediately if true, the current state will be pushed into the passed [map]
+ * @param processCurrentStateImmediately if true, the current state will be pushed immediately into the passed [map]
  * @param observer in order to be able to process the current state immediately, an observer function has
  * to be passed as argument here. The Selector is created inside this function, which makes it impossible to set any
  * observer function before processing the current state. If [processCurrentStateImmediately] is true anf [observer]
- * is null, then you will simply loose the current state. Every follow up state will be observed correctly though.
+ * is null, then you will simply lose the current state. Every follow-up state will be observed correctly though.
  * @param map the [map] function maps the state [STATE] to [VALUE]. The [VALUE] is published to the Selector
  * @return the Selector instance that was constructed out of [map]
  * @see addSelectorFromCallback
@@ -132,15 +132,11 @@ fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(
  * @return the SelectorToStateFlow instance that was constructed out of [map] - it's a MutableStateFlow under the hood
  * @see addSelectorFromCallback
  */
-fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(map: (STATE) -> VALUE): SelectorToStateFlow<STATE, VALUE> {
-    val initialValue = map(this.state)
-    val mutableStateFlow = MutableStateFlow(initialValue)
-    val selector = object : SelectorToStateFlow<STATE, VALUE>(mutableStateFlow) {
-        override fun map(state: STATE): VALUE = map(state)
-    }
-    addSelector(processCurrentStateImmediately = false, selector = selector)
-    return selector
-}
+fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(map: (STATE) -> VALUE): SelectorToStateFlow<STATE, VALUE> =
+    this.addSelectorStateFlow(
+        initialValue = map(this.state),
+        map = map
+    )
 
 /**
  * Remove the passed [stateObserver] from the observer list. This may be any StateObserver instance including Selectors

--- a/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
+++ b/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
@@ -126,7 +126,7 @@ fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(
  * Register a [map] as a Selector. This particular Selector extends a Kotlin coroutines MutableStateFlow and can be used as such.
  * The created Selector will be treated like any other StateObserver.
  *
- * The initial value of the MutableStateFlow will the result of [map] over the current state of the store receiver.
+ * The initial value of the MutableStateFlow is the result of [map] over the current state of the store receiver.
  *
  * @param map the [map] function maps the state [STATE] to [VALUE]. The [VALUE] is published to the created MutableStateFlow
  * @return the SelectorToStateFlow instance that was constructed out of [map] - it's a MutableStateFlow under the hood

--- a/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
+++ b/src/main/kotlin/de/db/moredux/observation/StateObservation.kt
@@ -106,21 +106,39 @@ fun <STATE : State, VALUE> Store<STATE>.addSelectorFromCallback(
  * The created Selector will be treated like any other StateObserver.
  *
  * @param initialValue the initial value o the created StateFlow
- * @param processCurrentStateImmediately if true, the current state will be pushed into the passed [map]
  * @param map the [map] function maps the state [STATE] to [VALUE]. The [VALUE] is published to the created MutableStateFlow
  * @return the SelectorToStateFlow instance that was constructed out of [map] - it's a MutableStateFlow under the hood
  * @see addSelectorFromCallback
  */
 fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(
     initialValue: VALUE,
-    processCurrentStateImmediately: Boolean = false,
     map: (STATE) -> VALUE
 ): SelectorToStateFlow<STATE, VALUE> {
     val mutableStateFlow = MutableStateFlow(initialValue)
     val selector = object : SelectorToStateFlow<STATE, VALUE>(mutableStateFlow) {
         override fun map(state: STATE): VALUE = map(state)
     }
-    addSelector(processCurrentStateImmediately, selector)
+    addSelector(processCurrentStateImmediately = false, selector)
+    return selector
+}
+
+/**
+ * Register a [map] as a Selector. This particular Selector extends a Kotlin coroutines MutableStateFlow and can be used as such.
+ * The created Selector will be treated like any other StateObserver.
+ *
+ * The initial value of the MutableStateFlow will the result of [map] over the current state of the store receiver.
+ *
+ * @param map the [map] function maps the state [STATE] to [VALUE]. The [VALUE] is published to the created MutableStateFlow
+ * @return the SelectorToStateFlow instance that was constructed out of [map] - it's a MutableStateFlow under the hood
+ * @see addSelectorFromCallback
+ */
+fun <STATE : State, VALUE> Store<STATE>.addSelectorStateFlow(map: (STATE) -> VALUE): SelectorToStateFlow<STATE, VALUE> {
+    val initialValue = map(this.state)
+    val mutableStateFlow = MutableStateFlow(initialValue)
+    val selector = object : SelectorToStateFlow<STATE, VALUE>(mutableStateFlow) {
+        override fun map(state: STATE): VALUE = map(state)
+    }
+    addSelector(processCurrentStateImmediately = false, selector = selector)
     return selector
 }
 

--- a/src/test/kotlin/de/db/moredux/observation/StateObservationTest.kt
+++ b/src/test/kotlin/de/db/moredux/observation/StateObservationTest.kt
@@ -251,13 +251,10 @@ class StateObservationTest {
     }
 
     @Test
-    fun `test addSelectorToStateFlow and processCurrentStateImmediately`() {
+    fun `test addSelectorToStateFlow without initial value`() {
         // Given
         val callbackState = mutableListOf<String>()
-        val selector = store.addSelectorStateFlow(
-            initialValue = "<initial value>",
-            processCurrentStateImmediately = true
-        ) { state ->
+        val selector = store.addSelectorStateFlow { state ->
             state.bla?.uppercase() ?: "<empty string>"
         }
         selector.observeSelector { callbackState.add(it) }
@@ -284,13 +281,12 @@ class StateObservationTest {
     }
 
     @Test
-    fun `test addSelectorToStateFlow and without processCurrentStateImmediately`() {
+    fun `test addSelectorToStateFlow and with initial value`() {
         // Given
         val callbackState = mutableListOf<String>()
-        val selector = store.addSelectorStateFlow(
-            initialValue = "<initial value>",
-            processCurrentStateImmediately = false
-        ) { state -> state.bla?.uppercase() ?: "<empty string>" }
+        val selector = store.addSelectorStateFlow(initialValue = "<initial value>") { state ->
+            state.bla?.uppercase() ?: "<empty string>"
+        }
 
         // Then
         assertThat(callbackState).hasSize(0)


### PR DESCRIPTION
Breaking change:
Refactoring of the StateObservation.addSelectorStateFlow(...) method into 2 separate methods that represent the processCurrentStateImmediately true and false. This is a simplifaction of the addSelectorStateFlow process